### PR TITLE
feat: support left-alignment as no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Align the given text per the line with the greatest [`string-width`](https://git
 
 - `opts.align`: string, default `'center'`
 
-   The alignment mode. Use `'center'` for center-alignment or `'right'` for right-alignment.
+   The alignment mode. Use `'center'` for center-alignment, `'right'` for right-alignment, or `'left'` for left-alignment. Note that the given `text` is assumed to be left-aligned already, so specifying `align: 'left'` just returns the `text` as is (no-op).
 
 - `opts.split`: string or RegExp, default `'\n'`
 
@@ -63,6 +63,10 @@ Alias for `ansiAlign(text, { align: 'center' })`.
 ### `ansiAlign.right(text)`
 
 Alias for `ansiAlign(text, { align: 'right' })`.
+
+### `ansiAlign.left(text)`
+
+Alias for `ansiAlign(text, { align: 'left' })`, which is a no-op.
 
 ## Similar Packages
 

--- a/index.js
+++ b/index.js
@@ -6,10 +6,14 @@ function ansiAlign (text, opts) {
   if (!text) return text
 
   opts = opts || {}
+  var align = opts.align || 'center'
+
+  // short-circuit `align: 'left'` as no-op
+  if (align === 'left') return text
+
   var split = opts.split || '\n'
   var pad = opts.pad || ' '
-  var align = opts.align || 'center'
-  var widthDiffFn = align !== 'center' ? fullDiff : halfDiff
+  var widthDiffFn = align !== 'right' ? halfDiff : fullDiff
 
   var returnString = false
   if (!Array.isArray(text)) {
@@ -32,6 +36,10 @@ function ansiAlign (text, opts) {
   })
 
   return returnString ? text.join(split) : text
+}
+
+ansiAlign.left = function left (text) {
+  return ansiAlign(text, { align: 'left' })
 }
 
 ansiAlign.center = function center (text) {

--- a/test/ansi-align.js
+++ b/test/ansi-align.js
@@ -37,6 +37,18 @@ test('accepts opts for split, pad, and align', (t) => {
   t.is(out, '........one two\tthree four five')
 })
 
+test('supports `align: \'left\'` as no-op', (t) => {
+  let inp = 'one two three\nfour five'
+  let out = ansiAlign(inp, { align: 'left' })
+  t.is(out, inp)
+})
+
+test('ansiAlign.left is alias for left align (no-op)', (t) => {
+  let inp = 'one two three\nfour five'
+  let out = ansiAlign.left(inp)
+  t.is(out, inp)
+})
+
 test('ansiAlign.center is alias for center align', (t) => {
   //    one
   //    two


### PR DESCRIPTION
As suggested in https://github.com/sindresorhus/boxen/pull/11#discussion_r65950146.

Also add `ansiAlign.left()` for consistency.
