### PR TITLE
feat: ES2015ify, dropping support for Node <4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.10'
   - '4'
+  - '6'
   - 'node'
 after_success: npm run coverage

--- a/index.js
+++ b/index.js
@@ -1,35 +1,35 @@
 'use strict'
 
-var stringWidth = require('string-width')
+const stringWidth = require('string-width')
 
 function ansiAlign (text, opts) {
   if (!text) return text
 
   opts = opts || {}
-  var align = opts.align || 'center'
+  const align = opts.align || 'center'
 
   // short-circuit `align: 'left'` as no-op
   if (align === 'left') return text
 
-  var split = opts.split || '\n'
-  var pad = opts.pad || ' '
-  var widthDiffFn = align !== 'right' ? halfDiff : fullDiff
+  const split = opts.split || '\n'
+  const pad = opts.pad || ' '
+  const widthDiffFn = align !== 'right' ? halfDiff : fullDiff
 
-  var returnString = false
+  let returnString = false
   if (!Array.isArray(text)) {
     returnString = true
     text = String(text).split(split)
   }
 
-  var width
-  var maxWidth = 0
+  let width
+  let maxWidth = 0
   text = text.map(function (str) {
     str = String(str)
     width = stringWidth(str)
     maxWidth = Math.max(width, maxWidth)
     return {
-      str: str,
-      width: width
+      str,
+      width
     }
   }).map(function (obj) {
     return new Array(widthDiffFn(maxWidth, obj.width) + 1).join(pad) + obj.str

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   },
   "homepage": "https://github.com/nexdrew/ansi-align#readme",
   "dependencies": {
-    "string-width": "^1.0.1"
+    "string-width": "^2.0.0"
   },
   "devDependencies": {
-    "ava": "^0.17.0",
+    "ava": "^0.19.1",
     "chalk": "^1.1.3",
-    "coveralls": "^2.11.9",
-    "nyc": "^10.1.2",
-    "standard": "^8.0.0",
+    "coveralls": "^2.13.1",
+    "nyc": "^10.3.0",
+    "standard": "^10.0.2",
     "standard-version": "^4.0.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Node 0.10 or 0.12 no longer supported, please update to Node 4+ or use ansi-align@1.1.0